### PR TITLE
Fix numpy version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@ lxml==5.3.0
 pypdf==5.0.1
 python-docx==1.1.2
 llama-cpp-python==0.2.90
-numpy==2.1.1
+# Use a NumPy version compatible with both llama-cpp-python and fastembed.
+# The previous pin to NumPy 2.x conflicted with fastembed, which requires
+# NumPy versions below 2. Pinning to the latest 1.x release resolves the
+# dependency issues while remaining within the supported range of
+# llama-cpp-python.
+numpy==1.26.4
 fastembed==0.3.6
 pydantic==2.9.2


### PR DESCRIPTION
## Summary
- pin numpy 1.26.4 so dependencies llama-cpp-python and fastembed resolve without conflict

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.112.2 due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e8b5c220832087b99652b1749801