### PR TITLE
Avoid heavy optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # raspi-llm-rag-api
 
-Minimal LLM + RAG API for Raspberry Pi 5. Designed to be managed via GitHub, with:
-- **Small LLM** (local via `llama-cpp-python`) or **Ollama**/**OpenAI** as fallback
+ Minimal LLM + RAG API for Raspberry Pi 5. Designed to be managed via GitHub, with:
+- **Small LLM** (local via optional `llama-cpp-python`) or **Ollama**/**OpenAI** as fallback
 - **RAG** ingestion for URLs & documents (PDF/DOCX/TXT/HTML)
 - **FastAPI** endpoints for ingest, search & chat
 
@@ -31,8 +31,8 @@ bash scripts/run.sh
 ```
 
 ### Env config
-Copy `.env.example` to `.env` and adjust:
-- `LLM_BACKEND`: `llama_cpp` (default), `ollama`, or `openai`
+Ensure a `.env` file exists (create from `.env.example` if provided) and adjust:
+- `LLM_BACKEND`: `llama_cpp` (requires manual install of `llama-cpp-python`), `ollama`, or `openai`
 - `LLAMA_MODEL_PATH`: path to your `.gguf` model file
 - `OLLAMA_MODEL`: e.g. `qwen2.5:1.5b-instruct` (if you run `ollama serve` on the Pi)
 - `OPENAI_API_KEY`: only if you want cloud fallback
@@ -45,8 +45,8 @@ Copy `.env.example` to `.env` and adjust:
 
 ### Notes for Raspberry Pi
 - Prefer **small** GGUF models (≤1.5–3B params, Q4 quant), e.g. Qwen2.5-1.5B-Instruct or Phi-3-mini.
-- If `llama-cpp-python` wheel fails to install, pip will compile; that can take a while on Pi.
-- Alternative: run **Ollama** on Pi (`curl -fsSL https://ollama.com/install.sh | sh`) and set `LLM_BACKEND=ollama`.
+- To use the local backend you must separately `pip install llama-cpp-python`.
+- Otherwise, run **Ollama** on Pi (`curl -fsSL https://ollama.com/install.sh | sh`) and set `LLM_BACKEND=ollama`.
 
 ### GitHub
 This repo is structured to be pushed directly to GitHub. Typical flow:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,4 @@
 import re, requests, bs4, pathlib
-import trafilatura
 from pypdf import PdfReader
 from docx import Document
 
@@ -9,14 +8,9 @@ def clean_text(text: str) -> str:
     return text
 
 def extract_from_url(url: str) -> str:
-    downloaded = trafilatura.fetch_url(url)
-    if downloaded:
-        txt = trafilatura.extract(downloaded, include_links=False, include_tables=False)
-        if txt:
-            return clean_text(txt)
-    # fallback: raw HTML text
-    html = requests.get(url, timeout=30).text
-    soup = bs4.BeautifulSoup(html, "lxml")
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    soup = bs4.BeautifulSoup(resp.text, "lxml")
     return clean_text(soup.get_text(" "))
 
 def extract_from_file(path: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,16 +3,10 @@ uvicorn==0.30.6
 python-dotenv==1.0.1
 requests==2.32.3
 beautifulsoup4==4.12.3
-trafilatura==1.12.1
 lxml==5.3.0
 pypdf==5.0.1
 python-docx==1.1.2
-llama-cpp-python==0.2.90
-# Use a NumPy version compatible with both llama-cpp-python and fastembed.
-# The previous pin to NumPy 2.x conflicted with fastembed, which requires
-# NumPy versions below 2. Pinning to the latest 1.x release resolves the
-# dependency issues while remaining within the supported range of
-# llama-cpp-python.
+# Pin NumPy to the latest 1.x release for fastembed compatibility.
 numpy==1.26.4
 fastembed==0.3.6
 pydantic==2.9.2


### PR DESCRIPTION
## Summary
- Drop `llama-cpp-python` and `trafilatura` from default requirements
- Simplify URL text extraction using `requests` and `BeautifulSoup`
- Document optional local LLM dependency in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.112.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ed9cf4d48320b56a53c72172c788