### PR TITLE
Add python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.112.2
 uvicorn==0.30.6
+python-multipart==0.0.9
 python-dotenv==1.0.1
 requests==2.32.3
 beautifulsoup4==4.12.3


### PR DESCRIPTION
## Summary
- add python-multipart to project requirements for handling file uploads

## Testing
- `python -m pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement fastapi==0.112.2)
- `python -m uvicorn app.main:app --host 0.0.0.0 --port 8000` (fails: No module named uvicorn)


------
https://chatgpt.com/codex/tasks/task_e_68c408a761b88320ae10f9583407ccd7