### PR TITLE
feat: add simple search and ingest frontend

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8" />
+    <title>RAG Frontend</title>
+</head>
+<body>
+    <h1>RAG Frontend</h1>
+
+    <section>
+        <h2>Sök</h2>
+        <form id="search-form">
+            <input type="text" id="search-query" placeholder="Sökfråga" />
+            <button type="submit">Sök</button>
+        </form>
+        <ul id="search-results"></ul>
+    </section>
+
+    <section>
+        <h2>Lägg till URL</h2>
+        <form id="url-form">
+            <input type="text" id="url-input" placeholder="https://" />
+            <button type="submit">Lägg till</button>
+        </form>
+        <div id="url-status"></div>
+    </section>
+
+    <section>
+        <h2>Ladda upp fil</h2>
+        <form id="file-form">
+            <input type="file" id="file-input" />
+            <button type="submit">Ladda upp</button>
+        </form>
+        <div id="file-status"></div>
+    </section>
+
+    <script>
+    document.getElementById('search-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const q = document.getElementById('search-query').value;
+        const res = await fetch(`/search?q=${encodeURIComponent(q)}`);
+        const data = await res.json();
+        const list = document.getElementById('search-results');
+        list.innerHTML = '';
+        data.results.forEach(r => {
+            const li = document.createElement('li');
+            li.textContent = `${r.text} (score: ${r.score.toFixed(3)})`;
+            list.appendChild(li);
+        });
+    });
+
+    document.getElementById('url-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const url = document.getElementById('url-input').value;
+        const res = await fetch('/ingest/url', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url })
+        });
+        const data = await res.json();
+        document.getElementById('url-status').textContent = JSON.stringify(data);
+    });
+
+    document.getElementById('file-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const file = document.getElementById('file-input').files[0];
+        if (!file) return;
+        const formData = new FormData();
+        formData.append('file', file);
+        const res = await fetch('/ingest/file', {
+            method: 'POST',
+            body: formData
+        });
+        const data = await res.json();
+        document.getElementById('file-status').textContent = JSON.stringify(data);
+    });
+    </script>
+</body>
+</html>

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 from typing import Optional
 import pathlib, shutil
@@ -7,6 +8,8 @@ from .settings import settings
 from .rag import ingest_url, ingest_file, search, DOCS_DIR
 from .llm import generate, build_rag_prompt
 
+FRONTEND_FILE = pathlib.Path(__file__).parent / "frontend" / "index.html"
+
 app = FastAPI(title="Raspberry Pi LLM + RAG API", version="0.1.0")
 
 class ChatReq(BaseModel):
@@ -14,6 +17,13 @@ class ChatReq(BaseModel):
     top_k: Optional[int] = None
     max_tokens: int = 256
     temperature: float = 0.2
+
+
+@app.get("/", response_class=HTMLResponse)
+def frontend():
+    if FRONTEND_FILE.exists():
+        return HTMLResponse(FRONTEND_FILE.read_text())
+    return HTMLResponse("<h1>Frontend not found</h1>", status_code=404)
 
 @app.get("/health")
 def health():


### PR DESCRIPTION
## Summary
- add minimal HTML page for searching and uploading material
- serve frontend at root path in FastAPI app

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c4165ef31c8320b21d6e19d5cc188e