### PR TITLE
feat: add chat interface to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Simple, local vector store (NumPy) + SQLite for metadata
 - Clean API: `/ingest/url`, `/ingest/file`, `/search`, `/chat`
 - Swedish Q&A out of the box – ask in Swedish and receive answers in Swedish
+- Minimal HTML frontend for search, ingest and chat (served at `/`)
 
 ## Quickstart (Raspberry Pi 5)
 ```bash

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -34,6 +34,15 @@
         <div id="file-status"></div>
     </section>
 
+    <section>
+        <h2>Chat</h2>
+        <div id="chat-log" style="white-space: pre-wrap;"></div>
+        <form id="chat-form">
+            <input type="text" id="chat-input" placeholder="Ställ en fråga..." />
+            <button type="submit">Skicka</button>
+        </form>
+    </section>
+
     <script>
     document.getElementById('search-form').addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -73,6 +82,25 @@
         });
         const data = await res.json();
         document.getElementById('file-status').textContent = JSON.stringify(data);
+    });
+
+    const chatForm = document.getElementById('chat-form');
+    const chatInput = document.getElementById('chat-input');
+    const chatLog = document.getElementById('chat-log');
+
+    chatForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const msg = chatInput.value.trim();
+        if (!msg) return;
+        chatLog.innerHTML += `<div><strong>Du:</strong> ${msg}</div>`;
+        chatInput.value = '';
+        const res = await fetch('/chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: msg })
+        });
+        const data = await res.json();
+        chatLog.innerHTML += `<div><strong>LLM:</strong> ${data.answer}</div>`;
     });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add chat section to HTML frontend
- document frontend availability in README

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c41c9c14588320979d598a4b05ec17