### PR TITLE
Set Ollama as default backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-LLM_BACKEND=llama_cpp
+LLM_BACKEND=ollama
 LLAMA_MODEL_PATH=./data/models/model.gguf
 OLLAMA_HOST=http://127.0.0.1:11434
 OLLAMA_MODEL=qwen2.5:1.5b-instruct

--- a/ANVÄNDARGUIDE.md
+++ b/ANVÄNDARGUIDE.md
@@ -67,6 +67,6 @@ http POST http://localhost:8000/chat message="Vad handlar dokumentet om?"
 ```
 
 ## Tips
-- Se till att `.env` är korrekt konfigurerad med rätt backend (`llama_cpp`, `ollama` eller `openai`).
+- Standardbackend är `ollama`, men se till att `.env` är korrekt konfigurerad med önskad backend (`ollama`, `llama_cpp` eller `openai`).
 - Använd små, kvantiserade GGUF-modeller för bästa prestanda på Raspberry Pi.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bash scripts/run.sh
 
 ### Env config
 Ensure a `.env` file exists (create from `.env.example` if provided) and adjust:
-- `LLM_BACKEND`: `llama_cpp` (requires manual install of `llama-cpp-python`), `ollama`, or `openai`
+- `LLM_BACKEND`: `ollama` (default), `llama_cpp` (requires manual install of `llama-cpp-python`), or `openai`
 - `LLAMA_MODEL_PATH`: path to your `.gguf` model file
 - `OLLAMA_MODEL`: e.g. `qwen2.5:1.5b-instruct` (if you run `ollama serve` on the Pi)
 - `OPENAI_API_KEY`: only if you want cloud fallback
@@ -47,7 +47,7 @@ Ensure a `.env` file exists (create from `.env.example` if provided) and adjust:
 ### Notes for Raspberry Pi
 - Prefer **small** GGUF models (≤1.5–3B params, Q4 quant), e.g. Qwen2.5-1.5B-Instruct or Phi-3-mini.
 - To use the local backend you must separately `pip install llama-cpp-python`.
-- Otherwise, run **Ollama** on Pi (`curl -fsSL https://ollama.com/install.sh | sh`) and set `LLM_BACKEND=ollama`.
+- Otherwise, run **Ollama** on Pi (`curl -fsSL https://ollama.com/install.sh | sh`) – this backend is now used by default.
 
 ### GitHub
 This repo is structured to be pushed directly to GitHub. Typical flow:

--- a/app/settings.py
+++ b/app/settings.py
@@ -5,7 +5,7 @@ import os
 load_dotenv()
 
 class Settings(BaseModel):
-    LLM_BACKEND: str = os.getenv("LLM_BACKEND", "llama_cpp")
+    LLM_BACKEND: str = os.getenv("LLM_BACKEND", "ollama")
     LLAMA_MODEL_PATH: str = os.getenv("LLAMA_MODEL_PATH", "./data/models/model.gguf")
     OLLAMA_HOST: str = os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434")
     OLLAMA_MODEL: str = os.getenv("OLLAMA_MODEL", "qwen2.5:1.5b-instruct")


### PR DESCRIPTION
## Summary
- Default to Ollama for language model backend
- Document Ollama as the standard backend in README and user guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4279a01e883209f62c3dea46304eb