### PR TITLE
Add LLM and Ollama status to frontend

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -8,6 +8,12 @@
     <h1>RAG Frontend</h1>
 
     <section>
+        <h2>Status</h2>
+        <div id="llm-status">LLM: ok?</div>
+        <div id="ollama-status">Ollama: ok?</div>
+    </section>
+
+    <section>
         <h2>Sök</h2>
         <form id="search-form">
             <input type="text" id="search-query" placeholder="Sökfråga" />
@@ -102,6 +108,26 @@
         const data = await res.json();
         chatLog.innerHTML += `<div><strong>LLM:</strong> ${data.answer}</div>`;
     });
+
+    async function uppdateraStatus() {
+        try {
+            const res = await fetch('/health');
+            if (!res.ok) {
+                const text = await res.text();
+                throw new Error(`HTTP ${res.status}: ${text}`);
+            }
+            const data = await res.json();
+            document.getElementById('llm-status').textContent = `LLM-backend (${data.backend}): ${data.llm ? 'OK' : 'Fel'}`;
+            document.getElementById('ollama-status').textContent = `Ollama: ${data.ollama ? 'OK' : 'Fel'}`;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            document.getElementById('llm-status').textContent = `LLM: Fel (${msg})`;
+            document.getElementById('ollama-status').textContent = `Ollama: Fel (${msg})`;
+            console.error(err);
+        }
+    }
+
+    uppdateraStatus();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand health endpoint to report LLM and Ollama availability
- show LLM and Ollama status in frontend
- display detailed error messages when health checks fail

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from app.main import health
print(health())
PY` *(fails: Could not download model BAAI/bge-small-en-v1.5 from any source)*

------
https://chatgpt.com/codex/tasks/task_e_68c434ec3208832097396643e7d0a0de