### PR TITLE
Handle JSON errors in Ollama health check

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,13 +38,15 @@ def health():
     try:
         r = requests.get(f"{settings.OLLAMA_HOST}/api/tags", timeout=5)
         r.raise_for_status()
-        ollama_ok = True
         tags = r.json()
+        if not isinstance(tags, dict):
+            raise ValueError("Unexpected JSON structure")
+        ollama_ok = True
         models = tags.get("models", [])
         ollama_model = any(m.get("name") == settings.OLLAMA_MODEL for m in models)
         if not ollama_model:
             ollama_model_error = f"Modell saknas: {settings.OLLAMA_MODEL}"
-    except requests.RequestException as e:
+    except (requests.RequestException, ValueError, AttributeError) as e:
         ollama_ok = False
         ollama_error = str(e)
 


### PR DESCRIPTION
## Summary
- handle JSON decoding or structure errors from Ollama `/api/tags` endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7d6934a908320a27e4e2a474bc4a3